### PR TITLE
VDecoder: get frame dimensions from video file

### DIFF
--- a/RustyRoseEngine/VDecoder.h
+++ b/RustyRoseEngine/VDecoder.h
@@ -33,8 +33,6 @@ private:
 	AVPacket* _packet;
 	AVFrame* _frame;
 
-	int _texFrameWidth;
-	int _texFrameHeight;
 	bool _texDimensionsValid;
 	SDL_Texture* _texture;
 

--- a/RustyRoseEngine/VDecoder.h
+++ b/RustyRoseEngine/VDecoder.h
@@ -33,11 +33,15 @@ private:
 	AVPacket* _packet;
 	AVFrame* _frame;
 
+	int _texFrameWidth;
+	int _texFrameHeight;
+	bool _texDimensionsValid;
 	SDL_Texture* _texture;
 
 	int _getWidthFrame();
 	int _getHeightFrame();
 	int* _getLinesize();
 	uint8_t** _getFrameData();
+	void _resizeTexture();
 };
 


### PR DESCRIPTION
sprawdzałem na plikach 1280x720(wmv) i 1920x1080(webm) i działa ale i tak sprawdź u siebie czy mi sie coś nie pojebało